### PR TITLE
03 calculator implemention - 계산기 구현 (context api, useReducer)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,10 @@
-import { useState } from 'react';
+import Calculator from './components/Calculator';
+import { CalculatorProvider } from './contexts/CalculatorContext';
 
 export default function App() {
-  const [total, setTotal] = useState(0);
-
   return (
-    <div className="calculator">
-      <h1 id="total">{total}</h1>
-      <div className="digits flex">
-        {CONST.DIGIT_LIST.map((digit) => (
-          <button key={digit} className="digit">
-            {digit}
-          </button>
-        ))}
-      </div>
-      <div className="modifiers subgrid">
-        <button className="modifier">{CONST.MODIFIER}</button>
-      </div>
-      <div className="operations subgrid">
-        {CONST.OPERATION_LIST.map((operation) => (
-          <button key={operation} className="operation">
-            {operation}
-          </button>
-        ))}
-      </div>
-    </div>
+    <CalculatorProvider>
+      <Calculator />
+    </CalculatorProvider>
   );
 }
-
-const CONST = {
-  DIGIT_LIST: Array.from({ length: 10 }, (_, index) => index).reverse(),
-  OPERATION_LIST: ['/', 'X', '-', '+', '='],
-  MODIFIER: 'AC',
-};

--- a/src/__test__/allClear.test.tsx
+++ b/src/__test__/allClear.test.tsx
@@ -13,13 +13,13 @@ describe.each([
   });
 
   it('초기 표시값은 0이다.', async () => {
-    const $total = await screen.findByRole('heading', { description: '0' });
+    const $total = await screen.findByRole('heading');
 
     expect($total.textContent).toBe('0');
   });
 
   it(`[${orderList},AC]를 순서대로 클릭하면 0이(가) 표시된다.`, async () => {
-    const $total = await screen.findByRole('heading', { description: '0' });
+    const $total = await screen.findByRole('heading');
     const $AC = await screen.findByRole('button', { name: 'AC' });
 
     for (const order of orderList) {

--- a/src/__test__/calculate.test.tsx
+++ b/src/__test__/calculate.test.tsx
@@ -15,13 +15,13 @@ describe.each([
     });
 
     it('초기 표시값은 0이다.', async () => {
-      const $total = await screen.findByRole('heading', { description: '0' });
+      const $total = await screen.findByRole('heading');
 
       expect($total.textContent).toBe('0');
     });
 
     it(`${a}을 클릭하면 ${a}이(가) 표시된다.`, async () => {
-      const $total = await screen.findByRole('heading', { description: '0' });
+      const $total = await screen.findByRole('heading');
       const $digitA = await screen.findByRole('button', { name: a });
 
       await userEvent.click($digitA);
@@ -30,7 +30,7 @@ describe.each([
     });
 
     it(`[${a}, ${operation}]를 순서대로 클릭하면 ${operation}가 나타난다.`, async () => {
-      const $total = await screen.findByRole('heading', { description: '0' });
+      const $total = await screen.findByRole('heading');
       const $digitA = await screen.findByRole('button', { name: a });
       const $operation = await screen.findByRole('button', { name: operation });
 
@@ -41,7 +41,7 @@ describe.each([
     });
 
     it(`[${a}, ${operation}, ${b}]를 순서대로 클릭하면 ${b}가 나타난다.`, async () => {
-      const $total = await screen.findByRole('heading', { description: '0' });
+      const $total = await screen.findByRole('heading');
       const $digitA = await screen.findByRole('button', { name: a });
       const $digitB = await screen.findByRole('button', { name: b });
       const $operation = await screen.findByRole('button', { name: operation });
@@ -54,10 +54,10 @@ describe.each([
     });
 
     it(`[${a}, ${operation}, ${b}, =]를 순서대로 클릭하면 ${total}이 나타난다.`, async () => {
-      const $total = await screen.findByRole('heading', { description: '0' });
-      const $digitA = await screen.findByRole('button', { name: '1' });
-      const $digitB = await screen.findByRole('button', { name: '2' });
-      const $operation = await screen.findByRole('button', { name: '+' });
+      const $total = await screen.findByRole('heading');
+      const $digitA = await screen.findByRole('button', { name: a });
+      const $digitB = await screen.findByRole('button', { name: b });
+      const $operation = await screen.findByRole('button', { name: operation });
       const $calculation = await screen.findByRole('button', { name: '=' });
 
       await userEvent.click($digitA);

--- a/src/__test__/exception.test.tsx
+++ b/src/__test__/exception.test.tsx
@@ -14,13 +14,13 @@ describe('예외 대상이 되는 경우', () => {
       });
 
       it('초기 표시값은 0이다.', async () => {
-        const $total = await screen.findByRole('heading', { description: '0' });
+        const $total = await screen.findByRole('heading');
 
         expect($total.textContent).toBe('0');
       });
 
       it(`[${orderList}]를 순서대로 클릭하면 ${total}이(가) 표시된다.`, async () => {
-        const $total = await screen.findByRole('heading', { description: '0' });
+        const $total = await screen.findByRole('heading');
 
         for (const order of orderList) {
           const $ = await screen.findByRole('button', { name: order });
@@ -40,13 +40,13 @@ describe('예외 대상이 되는 경우', () => {
       });
 
       it('초기 표시값은 0이다.', async () => {
-        const $total = await screen.findByRole('heading', { description: '0' });
+        const $total = await screen.findByRole('heading');
 
         expect($total.textContent).toBe('0');
       });
 
       it(`[${orderList}]를 순서대로 클릭하면 ${total}이(가) 표시된다.`, async () => {
-        const $total = await screen.findByRole('heading', { description: '0' });
+        const $total = await screen.findByRole('heading');
 
         for (const order of orderList) {
           const $ = await screen.findByRole('button', { name: order });
@@ -58,7 +58,7 @@ describe('예외 대상이 되는 경우', () => {
     }
   );
 
-  describe.each([{ orderList: ['1', '/', '0'] }])(
+  describe.each([{ orderList: ['1', '/', '0', '='] }])(
     '연산의 결과값이 Infinity일 경우 오류라는 문자열을 보여준다. (아이폰 참고)',
     ({ orderList }) => {
       beforeEach(() => {
@@ -66,13 +66,13 @@ describe('예외 대상이 되는 경우', () => {
       });
 
       it('초기 표시값은 0이다.', async () => {
-        const $total = await screen.findByRole('heading', { description: '0' });
+        const $total = await screen.findByRole('heading');
 
         expect($total.textContent).toBe('0');
       });
 
       it(`[${orderList}]를 순서대로 클릭하면 Infinity가 표시된다.`, async () => {
-        const $total = await screen.findByRole('heading', { description: '0' });
+        const $total = await screen.findByRole('heading');
 
         for (const order of orderList) {
           const $ = await screen.findByRole('button', { name: order });

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -1,0 +1,17 @@
+import { useCalculatorState } from '../hooks/useCalculatorContext';
+import Digits from './Digits';
+import Modifier from './Modifier';
+import Operations from './Operations';
+
+export default function Calculator() {
+  const state = useCalculatorState();
+
+  return (
+    <div className="calculator">
+      <h1 id="total">{state.total}</h1>
+      <Digits />
+      <Modifier />
+      <Operations />
+    </div>
+  );
+}

--- a/src/components/Digits.tsx
+++ b/src/components/Digits.tsx
@@ -1,0 +1,21 @@
+import { useCalculatorDispatch } from '../hooks/useCalculatorContext';
+import { CONST } from '../utils/const';
+
+export default function Digits() {
+  const dispatch = useCalculatorDispatch();
+
+  return (
+    <div className="digits flex">
+      {CONST.DIGIT_LIST.map((digit) => (
+        <button
+          key={digit}
+          className="digit"
+          name={digit}
+          onClick={() => dispatch({ type: 'digit', param: digit })}
+        >
+          {digit}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Modifier.tsx
+++ b/src/components/Modifier.tsx
@@ -1,0 +1,18 @@
+import { useCalculatorDispatch } from '../hooks/useCalculatorContext';
+import { CONST } from '../utils/const';
+
+export default function Modifier() {
+  const dispatch = useCalculatorDispatch();
+
+  return (
+    <div className="modifiers subgrid">
+      <button
+        className="modifier"
+        name={CONST.MODIFIER}
+        onClick={() => dispatch({ type: 'modifier' })}
+      >
+        {CONST.MODIFIER}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Operations.tsx
+++ b/src/components/Operations.tsx
@@ -1,0 +1,21 @@
+import { useCalculatorDispatch } from '../hooks/useCalculatorContext';
+import { CONST } from '../utils/const';
+
+export default function Operations() {
+  const dispatch = useCalculatorDispatch();
+
+  return (
+    <div className="operations subgrid">
+      {CONST.OPERATION_LIST.map((operation) => (
+        <button
+          key={operation}
+          className="operation"
+          name={operation}
+          onClick={() => dispatch({ type: 'operation', param: operation })}
+        >
+          {operation}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/contexts/CalculatorContext.tsx
+++ b/src/contexts/CalculatorContext.tsx
@@ -1,0 +1,89 @@
+import { createContext, useReducer } from 'react';
+import { DIGIT, OPERATION } from '../types';
+import { calculate, isOperation } from '../utils';
+import { CONST } from '../utils/const';
+
+type STATE = typeof initialState;
+type ACTION = ACTION_DIGIT | ACTION_MODIFIER | ACTION_OPERATION;
+type ACTION_DIGIT = {
+  type: 'digit';
+  param: DIGIT;
+};
+type ACTION_MODIFIER = {
+  type: 'modifier';
+};
+type ACTION_OPERATION = {
+  type: 'operation';
+  param: OPERATION;
+};
+
+export const CalculatorStateContext = createContext<STATE | null>(null);
+export const CalculatorDispatchContext =
+  createContext<React.Dispatch<ACTION> | null>(null);
+
+export function CalculatorProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <CalculatorStateContext.Provider value={state}>
+      <CalculatorDispatchContext.Provider value={dispatch}>
+        {children}
+      </CalculatorDispatchContext.Provider>
+    </CalculatorStateContext.Provider>
+  );
+}
+
+const reducer = (state: typeof initialState, action: ACTION) => {
+  const { total, memory } = state;
+  switch (action.type) {
+    case 'digit': {
+      if (total.length === CONST.DIGIT_MAX_LENGTH) {
+        return state;
+      }
+      if (total === '0' || isOperation(total)) {
+        return {
+          ...state,
+          total: action.param,
+        };
+      }
+      return {
+        ...state,
+        total: total.concat(action.param),
+      };
+    }
+    case 'modifier':
+      return initialState;
+    case 'operation': {
+      if (action.param === '=') {
+        const [leftNumber, operation] = memory;
+        const rightNumber = total;
+        const newTotal = calculate(
+          Number(leftNumber),
+          operation,
+          Number(rightNumber)
+        ).toString();
+        return {
+          total: newTotal,
+          memory: [newTotal],
+        };
+      }
+
+      return {
+        total: action.param,
+        memory: [state.total, action.param],
+      };
+    }
+    default: {
+      throw Error('Unknown action');
+    }
+  }
+};
+
+const initialState = {
+  total: '0',
+  memory: [] as string[],
+};

--- a/src/hooks/useCalculatorContext.ts
+++ b/src/hooks/useCalculatorContext.ts
@@ -1,0 +1,21 @@
+import { useContext } from 'react';
+import {
+  CalculatorDispatchContext,
+  CalculatorStateContext,
+} from '../contexts/CalculatorContext';
+
+export function useCalculatorState() {
+  const state = useContext(CalculatorStateContext);
+  if (state === null) {
+    throw new Error("Can't find CalculatorStateContext");
+  }
+  return state;
+}
+
+export function useCalculatorDispatch() {
+  const dispatch = useContext(CalculatorDispatchContext);
+  if (dispatch === null) {
+    throw new Error("Can't find CalculatorDispatchContext");
+  }
+  return dispatch;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+import type { CONST } from '../utils/const';
+
+export type DIGIT = (typeof CONST.DIGIT_LIST)[number];
+export type OPERATION = (typeof CONST.OPERATION_LIST)[number];

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,0 +1,8 @@
+export const CONST = {
+  DIGIT_LIST: ['9', '8', '7', '6', '5', '4', '3', '2', '1', '0'],
+  OPERATION_LIST: ['/', 'X', '-', '+', '='],
+  MODIFIER: 'AC',
+  INITIAL_TOTAL: '0',
+  INFINITY: 'Infinity',
+  DIGIT_MAX_LENGTH: 3,
+} as const;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,28 @@
+import type { OPERATION } from '../types';
+import { CONST } from './const';
+
+export function isOperation(order: OPERATION | string): order is OPERATION {
+  return CONST.OPERATION_LIST.some((operation) => operation === order);
+}
+
+export function calculate(
+  left: number,
+  operation: Omit<OPERATION, '='>,
+  right: number
+) {
+  switch (operation) {
+    case '+':
+      return left + right;
+    case '-':
+      return left - right;
+    case 'X':
+      return left * right;
+    case '/': {
+      if (right === 0) {
+        return CONST.INFINITY;
+      }
+      return Math.floor(left / right);
+    }
+  }
+  return CONST.INFINITY;
+}


### PR DESCRIPTION
# 작업내용

## TL;DR

- [x] `context api`와 `useReducer`를 이용하여 계산기 구현
- [x] 테스트 코드 오류 수정

## Description

### 계산기 로직 설명
- 계산기의 표시할 값(total)과 기억해야할 식(memory)으로 이루어진 state를 사용했습니다.
- `숫자` 클릭: total값에 뒷붙여서 추가했습니다. (예외 대상 - total값이 0인 경우, total값이 3자리인 경우, total이 연산자인 경우)
- `연산자` 클릭: 기존 total값과 연산자를 memory에 저장하고 total을 연산자로 바꾸었습니다.
- `연산자(=)` 클릭: 숫자-연산자-숫자를 입력하였다고 가정하고, memory와 total를 이용하여 계산한 결과값으로 memory와 total을 갱신하였습니다.
- `AC` 클릭: total과 memory를 초기화하였습니다.

### `context api` 와 `useReducer`를 사용의도
- 초기 구현에는 useReducer를 이용하여 dispatch를 감싼 함수(이하 dispatchWrapper함수)를 prop으로 1depth만 내려주는 구성을 했습니다. (commit을 누락하여 코드 참고가 어려운 부분 죄송합니다.) 이와 같은 구성에서는 해당 dispatch 실행에 필요한 param 값을 dispatchWrapper함수에서 인자로 받아야했습니다. 하지만 데이터(state - total값)를 사용하는 곳(상위 컴포넌트)와 데이터를 바꾸는 곳(하위 컴포넌트)이 명확하게 나누어져 있어서 상위 컴포넌트에서 데이터를 바꾸는 로직를 분리하고자 context api를 추가하였습니다. 전체 App컴포넌트의 전역 상태가 아닌 Calculator의 전역 상태로 두어 변경 범위를 좁혔고, Calculator의 하위 컴포넌트들은 종단에 있는 컴포넌트이므로 context api를 사용하면 가독성 이점까지 챙길 수 있다고 생각했습니다.
- 참고한 링크 : https://react.dev/learn/scaling-up-with-reducer-and-context